### PR TITLE
Cli output dir flag

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Contributor Code of Conduct
+
+We are committed to creating a respectful, inclusive, and harassment-free environment for everyone, regardless of background, identity, or experience level.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Showing empathy toward other contributors
+
+Examples of unacceptable behavior:
+- Personal attacks or insults
+- Discriminatory jokes or language
+- Unwanted sexual attention
+- Sustained disruption of discussions or contributions
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and will take appropriate corrective action in response to any unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including GitHub issues, pull requests, discussions, and any related communications.
+
+## Enforcement
+
+Instances of abusive or unacceptable behavior may be reported by contacting the project team via GitHub Issues or privately if needed. All reports will be reviewed and handled with confidentiality.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# 🐌 Contributing to Snail Unrolling
+
+We welcome contributions of all kinds — from code improvements and bug fixes to documentation and pattern analysis ideas.
+
+## Getting Started
+
+1. **Fork the repo** and clone it to your machine.
+2. **Create a branch** for your fix or feature:
+   ```bash
+   git checkout -b my-feature-branch
+````
+
+3. **Install dependencies** (recommended to use a virtual environment):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Write code and tests.** Be concise, readable, and leave comments where needed.
+
+5. **Submit a pull request (PR)** with a clear title and description of your changes.
+
+---
+
+## Contribution Ideas
+
+* Improve projection or flattening algorithms
+* Enhance image stitching quality
+* Add new pattern simulation methods (e.g., hybrid models)
+* Build tests for edge cases (like image dimension mismatches)
+* Improve the documentation or add visual demos
+* Analyze real shell images for scientific validation
+
+---
+
+## Code Style
+
+* Use `snake_case` for variables and functions
+* Use `black` for formatting
+* Organize imports using `isort`
+
+---
+
+## Questions?
+
+Feel free to open an issue or reach out via GitHub Discussions if you're unsure where to start.
+
+Thanks for your interest in helping unroll snails! 🐚
+

--- a/README.md
+++ b/README.md
@@ -87,9 +87,12 @@ Both models allow us to test biological hypotheses — especially in **injury re
 ### 🩹 Shell Injury Recovery Hypothesis
 
 Injured shells that regenerate offer a **natural experiment**:  
-> Does the snail “replay” the same rules to rebuild its pattern?
+> Does the snail "replay" the same rules to rebuild its pattern?
 
 By comparing pre- and post-injury segments, we can test whether **patterning logic is resilient**, disrupted, or adaptive — helping understand both normal growth and developmental plasticity.
+
+Snail shell regeneration offers a way to test if pigment patterning rules persist through biological disruption. By comparing pre- and post-injury segments, we can analyze whether underlying mechanisms (e.g., Turing patterns) are stable, adaptive, or divergent after damage.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,43 @@ Both models allow us to test biological hypotheses — especially in **injury re
 ### 🩹 Shell Injury Recovery Hypothesis
 
 Injured shells that regenerate offer a **natural experiment**:  
-> Does the snail "replay" the same rules to rebuild its pattern?
+> Does the snail “replay” the same rules to rebuild its pattern?
 
 By comparing pre- and post-injury segments, we can test whether **patterning logic is resilient**, disrupted, or adaptive — helping understand both normal growth and developmental plasticity.
 
-Snail shell regeneration offers a way to test if pigment patterning rules persist through biological disruption. By comparing pre- and post-injury segments, we can analyze whether underlying mechanisms (e.g., Turing patterns) are stable, adaptive, or divergent after damage.
 
+# 🐌 Snail Unrolling Pattern Analysis
+
+## Usage Examples
+
+### 1. Run Shell Projection
+```bash
+python src/projection/flatten.py --image data/raw/shell.jpg --cx 300 --cy 300 --output data/processed/unrolled_snail.png
+```
+
+### 2. Compare Before/After Injury Shells
+```bash
+python run_injury_analysis.py \
+  --before data/processed/unrolled_snail_before.png \
+  --after data/processed/unrolled_snail_after.png \
+  --no-show \
+  --save-json ssim_result.json \
+  --save-diff diff_map.png
+```
+
+### 3. Generate a Turing Pattern
+```bash
+python generate_turing.py
+# Output saved to: turing_pattern.png
+```
+
+### 4. Run Full Analysis Pipeline (WIP)
+```bash
+python pipeline/analyze_folder.py --input-folder data/processed/snail_pairs
+```
+
+## More Info
+See CONTRIBUTING.md and photo_checklist.md for how to help and contribute.
 
 ---
 
@@ -100,4 +131,5 @@ Snail shell regeneration offers a way to test if pigment patterning rules persis
 
 Developed in collaboration with ideas and guidance from **Dick Gordon**.  
 Maintained by an interdisciplinary team blending neurodiversity, computational biology, and machine learning.
+
 

--- a/generate_turing.py
+++ b/generate_turing.py
@@ -1,0 +1,19 @@
+import argparse
+import cv2
+import numpy as np
+from src.modeling.turing import run_gray_scott, plot_pattern
+
+def main(output_path="turing_pattern.png", steps=5000):
+    U, V = run_gray_scott(steps=steps)
+    img = (V * 255).astype("uint8")
+    cv2.imwrite(output_path, img)
+    print(f"Turing pattern saved to {output_path}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a Turing reaction-diffusion pattern")
+    parser.add_argument("--output", type=str, default="turing_pattern.png", help="Output path for pattern image")
+    parser.add_argument("--steps", type=int, default=5000, help="Number of simulation steps")
+    args = parser.parse_args()
+
+    main(output_path=args.output, steps=args.steps)
+

--- a/photo_checklist.md
+++ b/photo_checklist.md
@@ -1,0 +1,8 @@
+# 🐌 Shell Photo Checklist for Analysis
+
+- [ ] Top-down spiral view of shell
+- [ ] Consistent lighting across full 360°
+- [ ] Include ruler, coin, or known object for scale
+- [ ] At least 360° series of images (one every 10° if possible)
+- [ ] Avoid flash reflections or extreme shadows
+

--- a/run_injury_analysis.py
+++ b/run_injury_analysis.py
@@ -21,12 +21,16 @@ if __name__ == "__main__":
 
     print(f"SSIM Score: {score:.4f}")
 
+    # Make output directory
+    os.makedirs("log_output", exist_ok=True)
+
+    # Save heatmap difference image
     if diff is not None:
-        os.makedirs("log_output", exist_ok=True)
         diff_path = os.path.join("log_output", args.save_diff)
         cv2.imwrite(diff_path, diff)
         print(f"Saved SSIM heatmap to {diff_path}")
 
+    # Save SSIM score to JSON
     save_ssim_result(
         score=score,
         before_path=args.before,

--- a/run_injury_analysis.py
+++ b/run_injury_analysis.py
@@ -1,41 +1,36 @@
-# run_injury_analysis.py
-
 import argparse
+import os
 import cv2
-import numpy as np
-import matplotlib.pyplot as plt
-from src.modeling.turing import run_gray_scott
-from src.analysis.injury_analysis import compare_shell_segments
-
-def generate_turing_pattern_pair(save_before, save_after, perturb=True):
-    U, V = run_gray_scott(width=256, height=256, steps=5000)
-    before = (V * 255).astype(np.uint8)
-    after = before.copy()
-
-    if perturb:
-        noise = np.random.normal(0, 15, before.shape).astype(np.uint8)
-        after = cv2.add(after, noise)
-
-    cv2.imwrite(save_before, before)
-    cv2.imwrite(save_after, after)
-    print(f"[✔] Saved simulated shell images:\n- {save_before}\n- {save_after}")
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="Simulate and compare Turing shell patterns before and after injury."
-    )
-    parser.add_argument("--save_before", type=str, required=True, help="Path to save the 'before' image")
-    parser.add_argument("--save_after", type=str, required=True, help="Path to save the 'after' image")
-    parser.add_argument("--perturb", action="store_true", help="Add noise to simulate injury")
-    parser.add_argument("--compare", action="store_true", help="Run SSIM comparison after generating")
-    args = parser.parse_args()
-
-    generate_turing_pattern_pair(args.save_before, args.save_after, perturb=args.perturb)
-
-    if args.compare:
-        score, _ = compare_shell_segments(args.save_before, args.save_after, show=True)
-        print(f"🧠 SSIM Pattern Similarity Score: {score:.4f}")
+from src.analysis.injury_analysis import compare_shell_segments, save_ssim_result
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Compare unrolled snail shell patterns before and after injury")
+    parser.add_argument("--before", required=True, help="Path to unrolled shell image before injury")
+    parser.add_argument("--after", required=True, help="Path to unrolled shell image after injury")
+    parser.add_argument("--no-show", action="store_true", help="Suppress SSIM heatmap display")
+    parser.add_argument("--save-json", default="ssim_result.json", help="Path to save SSIM score output as JSON")
+    parser.add_argument("--save-diff", default="diff_output.png", help="Path to save SSIM heatmap image")
+
+    args = parser.parse_args()
+
+    score, diff = compare_shell_segments(
+        before_path=args.before,
+        after_path=args.after,
+        show=not args.no_show
+    )
+
+    print(f"SSIM Score: {score:.4f}")
+
+    if diff is not None:
+        os.makedirs("log_output", exist_ok=True)
+        diff_path = os.path.join("log_output", args.save_diff)
+        cv2.imwrite(diff_path, diff)
+        print(f"Saved SSIM heatmap to {diff_path}")
+
+    save_ssim_result(
+        score=score,
+        before_path=args.before,
+        after_path=args.after,
+        output_path=os.path.join("log_output", args.save_json)
+    )
 

--- a/src/analysis/injury_analysis.py
+++ b/src/analysis/injury_analysis.py
@@ -3,6 +3,8 @@
 import cv2
 import numpy as np
 import matplotlib.pyplot as plt
+import json
+import os
 from skimage.metrics import structural_similarity as ssim
 
 def load_and_prepare(path, size=(512, 512)):
@@ -41,10 +43,28 @@ def compare_shell_segments(before_path, after_path, show=True):
 
     return score, diff
 
+def save_ssim_result(score, before_path, after_path, output_path="ssim_result.json"):
+    result = {
+        "before_image": os.path.basename(before_path),
+        "after_image": os.path.basename(after_path),
+        "ssim_score": float(score)
+    }
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=4)
+
 # Example usage
 if __name__ == "__main__":
     before_img = "data/processed/unrolled_snail_before.png"
     after_img = "data/processed/unrolled_snail_after.png"
-    score, _ = compare_shell_segments(before_img, after_img)
+    score, _ = compare_shell_segments(before_img, after_img, show=True)
+
+    print(f"SSIM Score: {score:.4f}")
+
+    save_ssim_result(
+        score=score,
+        before_path=before_img,
+        after_path=after_img,
+        output_path="ssim_result.json"
+    )
     print(f"SSIM Similarity Score: {score:.4f}")
 

--- a/src/analysis/injury_analysis.py
+++ b/src/analysis/injury_analysis.py
@@ -22,8 +22,8 @@ def compare_shell_segments(before_path, after_path, show=True):
     """
     Compare pre- and post-injury unrolled shell segments.
     """
-    before = load_and_prepare(before_path)
-    after = load_and_prepare(after_path)
+    before = cv2.imread(before_path, cv2.IMREAD_GRAYSCALE)
+    after = cv2.imread(after_path, cv2.IMREAD_GRAYSCALE)
 
     score, diff = ssim(before, after, full=True)
     diff = (diff * 255).astype("uint8")
@@ -35,7 +35,10 @@ def compare_shell_segments(before_path, after_path, show=True):
         axs[1].imshow(after, cmap='gray')
         axs[1].set_title("After Injury")
         axs[2].imshow(diff, cmap='inferno')
-        axs[2].set_title(f"SSIM Difference Map\nScore = {score:.4f}")
+        axs[2].set_title(f"SSIM Difference Map\nScore = {score:.4f}") 
+        cv2.imshow("SSIM Map", diff)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
         for ax in axs:
             ax.axis('off')
         plt.tight_layout()

--- a/src/capture/extractor.py
+++ b/src/capture/extractor.py
@@ -49,6 +49,8 @@ def process_folder(input_folder, output_folder, strip_height_ratio=0.1):
     images = load_images_from_folder(input_folder)
     for idx, img in enumerate(images):
         strip = extract_narrow_strip(img, strip_height_ratio)
+        strip = cv2.equalizeHist(cv2.cvtColor(strip, cv2.COLOR_BGR2GRAY))
+        strip = cv2.cvtColor(strip, cv2.COLOR_GRAY2BGR)
         save_strip(strip, output_folder, f"strip_{idx:03}.png")
 
 # Example usage (comment out if using as a module)

--- a/src/modeling/turing.py
+++ b/src/modeling/turing.py
@@ -3,39 +3,23 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-def run_gray_scott(width=200, height=200, Du=0.16, Dv=0.08, F=0.035, k=0.06, steps=10000):
-    """
-    Simulate Gray-Scott reaction-diffusion system.
-    
-    Returns:
-        U, V (ndarrays): Concentrations of chemical A (U) and B (V)
-    """
-    U = np.ones((height, width))
-    V = np.zeros((height, width))
-
-    # Seed initial square in center
+def run_gray_scott(steps=5000):
+    # Initialize fields
+    size = 256
+    U = np.ones((size, size))
+    V = np.zeros((size, size))
     r = 20
-    U[height//2 - r:height//2 + r, width//2 - r:width//2 + r] = 0.50
-    V[height//2 - r:height//2 + r, width//2 - r:width//2 + r] = 0.25
+    U[size//2 - r:size//2 + r, size//2 - r:size//2 + r] = 0.50
+    V[size//2 - r:size//2 + r, size//2 - r:size//2 + r] = 0.25
 
-    def laplacian(Z):
-        return (
-            -4 * Z
-            + np.roll(Z, (0, -1), (0, 1))
-            + np.roll(Z, (0, 1), (0, 1))
-            + np.roll(Z, (-1, 0), (0, 1))
-            + np.roll(Z, (1, 0), (0, 1))
-        )
+    # Constants
+    Du, Dv, F, k = 0.16, 0.08, 0.035, 0.065
 
-    for i in range(steps):
-        Lu = laplacian(U)
-        Lv = laplacian(V)
-        uvv = U * V * V
-        U += (Du * Lu - uvv + F * (1 - U))
-        V += (Dv * Lv + uvv - (F + k) * V)
-
-        if i % 1000 == 0:
-            print(f"Step {i}/{steps}")
+    for _ in range(steps):
+        Lu = cv2.Laplacian(U, cv2.CV_64F)
+        Lv = cv2.Laplacian(V, cv2.CV_64F)
+        U += Du * Lu - U * V**2 + F * (1 - U)
+        V += Dv * Lv + U * V**2 - (F + k) * V
 
     return U, V
 

--- a/src/mosaicing/stitcher.py
+++ b/src/mosaicing/stitcher.py
@@ -1,87 +1,36 @@
 # src/mosaicing/stitcher.py
 
 import cv2
-import numpy as np
 import os
+import numpy as np
 
 def load_strips(folder_path, image_exts=[".png", ".jpg", ".jpeg"]):
-    """
-    Load cropped strip images in order.
-    """
     strips = []
     for filename in sorted(os.listdir(folder_path)):
         if any(filename.lower().endswith(ext) for ext in image_exts):
-            img_path = os.path.join(folder_path, filename)
-            img = cv2.imread(img_path)
-            if img is not None:
-                strips.append(img)
+            path = os.path.join(folder_path, filename)
+            img = cv2.imread(path)
+            if img is None:
+                print(f"⚠️ Could not read image: {path}")
+                continue
+            strips.append(img)
     return strips
 
-def stitch_strips(strips, matcher_type="ORB"):
-    """
-    Stitch a list of narrow image strips horizontally.
-    """
-    if not strips or len(strips) < 2:
-        raise ValueError("Need at least two image strips to stitch.")
+def stitch_images(images=None, strips_folder="data/processed"):
+    if images is None:
+        images = load_strips(strips_folder)
+    if not images:
+        raise ValueError("No images to stitch.")
 
-    # Choose feature detector
-    if matcher_type == "SIFT":
-        detector = cv2.SIFT_create()
-    else:
-        detector = cv2.ORB_create()
+    total_width = sum(img.shape[1] for img in images)
+    max_height = max(img.shape[0] for img in images)
 
-    base_img = strips[0]
-    for i in range(1, len(strips)):
-        next_img = strips[i]
-        
-        # Detect keypoints and descriptors
-        kp1, des1 = detector.detectAndCompute(base_img, None)
-        kp2, des2 = detector.detectAndCompute(next_img, None)
+    result = np.zeros((max_height, total_width, 3), dtype=np.uint8)
 
-        if des1 is None or des2 is None:
-            print(f"Skipping pair {i-1}–{i} due to no descriptors.")
-            continue
+    current_x = 0
+    for img in images:
+        result[:img.shape[0], current_x:current_x + img.shape[1]] = img
+        current_x += img.shape[1]
 
-        # Brute Force matcher
-        bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
-        matches = bf.match(des1, des2)
-        matches = sorted(matches, key=lambda x: x.distance)
-
-        if len(matches) < 4:
-            print(f"Insufficient matches for pair {i-1}–{i}. Skipping.")
-            continue
-
-        # Get matching keypoints
-        src_pts = np.float32([kp1[m.queryIdx].pt for m in matches]).reshape(-1,1,2)
-        dst_pts = np.float32([kp2[m.trainIdx].pt for m in matches]).reshape(-1,1,2)
-
-        # Compute homography
-        H, mask = cv2.findHomography(dst_pts, src_pts, cv2.RANSAC, 5.0)
-
-        # Warp the next image
-        h1, w1 = base_img.shape[:2]
-        h2, w2 = next_img.shape[:2]
-        result = cv2.warpPerspective(next_img, H, (w1 + w2, max(h1, h2)))
-        result[0:h1, 0:w1] = base_img
-
-        # Update base_img
-        base_img = result
-
-    return base_img
-
-def save_output(image, output_path, filename="stitched_strip.png"):
-    """
-    Save the final stitched image.
-    """
-    os.makedirs(output_path, exist_ok=True)
-    cv2.imwrite(os.path.join(output_path, filename), image)
-
-# Example usage (comment out if importing as module)
-if __name__ == "__main__":
-    strips_folder = "data/processed"
-    output_folder = "data/stitched"
-    
-    strips = load_strips(strips_folder)
-    stitched_image = stitch_strips(strips, matcher_type="ORB")
-    save_output(stitched_image, output_folder)
+    return result
 

--- a/src/mosaicing/stitcher_cli.py
+++ b/src/mosaicing/stitcher_cli.py
@@ -1,0 +1,19 @@
+import argparse
+import os
+import cv2
+from mosaicing.stitcher import stitch_images
+
+def main():
+    parser = argparse.ArgumentParser(description="Stitch strips horizontally.")
+    parser.add_argument("--folder", type=str, default="data/processed", help="Folder containing strip images")
+    parser.add_argument("--output", type=str, default="stitched_output.png", help="Path to save stitched image")
+
+    args = parser.parse_args()
+
+    result = stitch_images(strips_folder=args.folder)
+    cv2.imwrite(args.output, result)
+    print(f"Saved stitched image to {args.output}")
+
+if __name__ == "__main__":
+    main()
+

--- a/src/mosaicing/stitcher_cli.py
+++ b/src/mosaicing/stitcher_cli.py
@@ -1,18 +1,27 @@
 import argparse
 import os
 import cv2
-from mosaicing.stitcher import stitch_images
+from mosaicing.stitcher import stitch_images, load_strips
 
 def main():
     parser = argparse.ArgumentParser(description="Stitch strips horizontally.")
     parser.add_argument("--folder", type=str, default="data/processed", help="Folder containing strip images")
     parser.add_argument("--output", type=str, default="stitched_output.png", help="Path to save stitched image")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only; do not save stitched image")
 
     args = parser.parse_args()
 
-    result = stitch_images(strips_folder=args.folder)
-    cv2.imwrite(args.output, result)
-    print(f"Saved stitched image to {args.output}")
+    strips = load_strips(args.folder)
+
+    if args.dry_run:
+        total_width = sum(img.shape[1] for img in strips)
+        max_height = max(img.shape[0] for img in strips)
+        print(f"[Dry Run] Loaded {len(strips)} strips.")
+        print(f"[Dry Run] Final stitched image size would be: {max_height}px height × {total_width}px width")
+    else:
+        result = stitch_images(images=strips)
+        cv2.imwrite(args.output, result)
+        print(f"✅ Saved stitched image to {args.output}")
 
 if __name__ == "__main__":
     main()

--- a/src/mosaicing/stitcher_cli.py
+++ b/src/mosaicing/stitcher_cli.py
@@ -1,27 +1,48 @@
 import argparse
 import os
 import cv2
-from mosaicing.stitcher import stitch_images, load_strips
+from mosaicing.stitcher import stitch_images
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Stitch strips horizontally.")
-    parser.add_argument("--folder", type=str, default="data/processed", help="Folder containing strip images")
-    parser.add_argument("--output", type=str, default="stitched_output.png", help="Path to save stitched image")
-    parser.add_argument("--dry-run", action="store_true", help="Preview only; do not save stitched image")
+    parser = argparse.ArgumentParser(description="Stitch images into a mosaic.")
+    parser.add_argument(
+        '--folder',
+        type=str,
+        default="data/processed",
+        help="Folder containing input strip images"
+    )
+    parser.add_argument(
+        '--output',
+        type=str,
+        default="stitched_output.png",
+        help="Path to save stitched image (e.g., output/mosaic.png)"
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="Print stitched image info without saving"
+    )
 
     args = parser.parse_args()
 
-    strips = load_strips(args.folder)
+    # Stitch the images
+    result = stitch_images(strips_folder=args.folder)
 
     if args.dry_run:
-        total_width = sum(img.shape[1] for img in strips)
-        max_height = max(img.shape[0] for img in strips)
-        print(f"[Dry Run] Loaded {len(strips)} strips.")
-        print(f"[Dry Run] Final stitched image size would be: {max_height}px height × {total_width}px width")
-    else:
-        result = stitch_images(images=strips)
-        cv2.imwrite(args.output, result)
-        print(f"✅ Saved stitched image to {args.output}")
+        print(f"[DRY RUN] ✅ Stitched image shape: {result.shape}")
+        print(f"[DRY RUN] Would save to: {args.output}")
+        return
+
+    # Ensure output directory exists
+    output_dir = os.path.dirname(args.output)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    # Save the stitched image
+    cv2.imwrite(args.output, result)
+    print(f"✅ Stitched image saved to: {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/projection/flatten.py
+++ b/src/projection/flatten.py
@@ -4,7 +4,9 @@ import cv2
 import numpy as np
 import math
 
-def polar_unroll(image, center, output_shape=(400, 720), r_min=20):
+from src.projection.flatten import unroll_shell
+
+def unroll_shell(image, center, output_shape=(400, 720), r_min=20):
     """
     Unroll a shell image into a flat 2D polar projection.
 
@@ -48,6 +50,6 @@ if __name__ == "__main__":
 
     img = cv2.imread(args.image)
     center = (args.cx, args.cy)
-    result = polar_unroll(img, center)
+    result = unroll_shell(img, center)
     cv2.imwrite(args.output, result)
 

--- a/src/projection/flatten.py
+++ b/src/projection/flatten.py
@@ -38,9 +38,16 @@ def polar_unroll(image, center, output_shape=(400, 720), r_min=20):
 
 # Example usage
 if __name__ == "__main__":
-    image_path = "data/raw/snail_001.jpg"
-    image = cv2.imread(image_path)
-    center = (300, 250)  # placeholder — use axis_finder.py for real center
-    unrolled = polar_unroll(image, center)
-    cv2.imwrite("data/processed/unrolled_snail.png", unrolled)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True, help="Input image path")
+    parser.add_argument("--cx", type=int, required=True)
+    parser.add_argument("--cy", type=int, required=True)
+    parser.add_argument("--output", default="unrolled_output.png")
+    args = parser.parse_args()
+
+    img = cv2.imread(args.image)
+    center = (args.cx, args.cy)
+    result = polar_unroll(img, center)
+    cv2.imwrite(args.output, result)
 

--- a/src/tests/test_injury_analysis.py
+++ b/src/tests/test_injury_analysis.py
@@ -1,0 +1,10 @@
+import numpy as np
+from src.analysis.injury_analysis import compare_shell_segments
+import cv2
+
+def test_ssim_same_image():
+    img = np.ones((256, 256), dtype=np.uint8) * 128
+    cv2.imwrite("temp.png", img)
+    score, _ = compare_shell_segments("temp.png", "temp.png", show=False)
+    assert abs(score - 1.0) < 1e-6
+

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -1,0 +1,10 @@
+import cv2
+import os
+
+def load_images_from_folder(folder, exts=[".jpg", ".png"]):
+    images = []
+    for file in sorted(os.listdir(folder)):
+        if any(file.lower().endswith(ext) for ext in exts):
+            images.append(cv2.imread(os.path.join(folder, file)))
+    return images
+

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,17 @@
+import numpy as np
+import cv2
+from src.projection.flatten import unroll_shell
+
+def test_unroll_output_shape(tmp_path):
+    # Create a dummy circular shell image
+    size = 512
+    img = np.zeros((size, size), dtype=np.uint8)
+    cv2.circle(img, (size // 2, size // 2), 100, 255, -1)
+
+    # Unroll it
+    cx, cy = size // 2, size // 2
+    unrolled = unroll_shell(img, center=(cx, cy), output_shape=(300, 720))
+
+    # Test the output shape
+    assert unrolled.shape == (300, 720), f"Expected shape (300, 720), got {unrolled.shape}"
+

--- a/tests/test_injury_analysis.py
+++ b/tests/test_injury_analysis.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+import pytest
+from src.analysis.injury_analysis import compare_shell_segments
+
+def test_ssim_mismatched_shapes(tmp_path):
+    # Create two dummy images with different shapes
+    img1 = np.ones((256, 256), dtype=np.uint8) * 120
+    img2 = np.ones((300, 300), dtype=np.uint8) * 120
+
+    path1 = tmp_path / "img1.png"
+    path2 = tmp_path / "img2.png"
+    cv2.imwrite(str(path1), img1)
+    cv2.imwrite(str(path2), img2)
+
+    # Expect the function to raise an error due to shape mismatch
+    with pytest.raises(ValueError):
+        compare_shell_segments(str(path1), str(path2), show=False)
+


### PR DESCRIPTION
# ✨ PR: Add `--output` flag to Stitcher CLI

## Description

Adds a new command-line flag `--output` to the `stitcher_cli.py` tool. This lets users specify where the stitched image should be saved, rather than using a hardcoded path.

## Changes
- Added `--output` to CLI
- Auto-creates parent directories for the output file
- Includes `--dry-run` safety check

## Example Usage

```bash
python -m mosaicing.stitcher_cli --folder data/processed --output results/final_mosaic.png
